### PR TITLE
PowerPoint 画像化ツールの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # sandbox
+
+このリポジトリには PowerPoint ファイルをページごとに画像化するツールが含まれています。
+
+## ツールの使い方
+
+1. `tools/ppt_to_images.py` を実行します。
+2. 第一引数に変換したい `.pptx` ファイルのパス、第二引数に画像を出力するディレクトリを指定してください。
+
+```bash
+python tools/ppt_to_images.py sample.pptx output_dir
+```
+
+LibreOffice がインストールされている必要があります。初回実行時は `apt-get install libreoffice-impress` でインストールしてください。

--- a/tools/ppt_to_images.py
+++ b/tools/ppt_to_images.py
@@ -1,0 +1,29 @@
+import argparse
+import os
+from pptx2img.converter import PPTXConverter, FileHandlingError, ConversionError, LibreOfficeNotFoundError
+
+
+def ppt_to_images(pptx_path: str, output_dir: str) -> None:
+    """指定されたPPTXファイルを画像化する"""
+    converter = PPTXConverter()
+    try:
+        converter.convert_pptx_to_images(pptx_path, output_dir)
+    except (FileHandlingError, ConversionError, LibreOfficeNotFoundError) as e:
+        raise RuntimeError(f"変換に失敗しました: {e}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="PowerPointを画像に変換するツール")
+    parser.add_argument("pptx", help="変換したいPPTXファイルのパス")
+    parser.add_argument("output_dir", help="出力先ディレクトリ")
+    args = parser.parse_args()
+
+    pptx_path = os.path.abspath(args.pptx)
+    output_dir = os.path.abspath(args.output_dir)
+    ppt_to_images(pptx_path, output_dir)
+    print(f"画像を {output_dir} に出力しました")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- tools ディレクトリを作成し、PPTX を画像に変換する `ppt_to_images.py` を追加
- README を日本語で更新し、ツールの使い方を追記

## Testing
- `python -m py_compile tools/ppt_to_images.py`


------
https://chatgpt.com/codex/tasks/task_e_687de9102f8483279e09726d1c7f11b4