### PR TITLE
Add devcontainer setup for Python Codespace

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/devcontainers/python:0-3.11
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libreoffice-impress \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+    "name": "Python Codespace",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "postCreateCommand": "if [ -f requirements.txt ]; then pip install -r requirements.txt; fi",
+    "customizations": {
+        "vscode": {
+            "extensions": ["ms-python.python"]
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -12,3 +12,9 @@ python tools/ppt_to_images.py sample.pptx output_dir
 ```
 
 LibreOffice がインストールされている必要があります。初回実行時は `apt-get install libreoffice-impress` でインストールしてください。
+
+## Codespaces での使用
+
+GitHub Codespaces で開くと自動的に devcontainer が構築され、必要な Python 環境と LibreOffice がインストールされます。
+初回起動時には `requirements.txt` の内容も自動でインストールされます。
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pptx2img


### PR DESCRIPTION
## Summary
- add devcontainer files to run Python in Codespaces
- install LibreOffice for conversion
- specify `pptx2img` dependency
- mention Codespaces usage in README

## Testing
- `python -m py_compile tools/ppt_to_images.py`

------
https://chatgpt.com/codex/tasks/task_e_6881c4daaef08327a0c871538c665cdb